### PR TITLE
extract emails from Tripit profile

### DIFF
--- a/lib/passport-tripit/strategy.js
+++ b/lib/passport-tripit/strategy.js
@@ -88,7 +88,7 @@ Strategy.prototype.userProfile = function(token, tokenSecret, params, done) {
       if (!Array.isArray(profile.emails)) {
         profile.emails = [profile.emails];
       }
-      profile.emails = profile.emails.map(function(email) { return email.address; });
+      profile.emails = profile.emails.map(function(email) { return { value: email.address }; });
 
       profile._raw = body;
       profile._json = json;

--- a/lib/passport-tripit/strategy.js
+++ b/lib/passport-tripit/strategy.js
@@ -76,18 +76,23 @@ util.inherits(Strategy, OAuthStrategy);
 Strategy.prototype.userProfile = function(token, tokenSecret, params, done) {
   this._oauth.get('https://api.tripit.com/v1/get/profile?format=json', token, tokenSecret, function (err, body, res) {
     if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
-    
+
     try {
       var json = JSON.parse(body);
-      
+
       var profile = { provider: 'tripit' };
       profile.id = json['Profile']['@attributes']['ref'];
       profile.username = json['Profile']['screen_name'];
       profile.displayName = json['Profile']['public_display_name'];
-      
+      profile.emails = json['Profile']['ProfileEmailAddresses']['ProfileEmailAddress'];
+      if (!Array.isArray(profile.emails)) {
+        profile.emails = [profile.emails];
+      }
+      profile.emails = profile.emails.map(function(email) { return email.address; });
+
       profile._raw = body;
       profile._json = json;
-      
+
       done(null, profile);
     } catch(e) {
       done(e);

--- a/test/strategy-test.js
+++ b/test/strategy-test.js
@@ -91,8 +91,8 @@ vows.describe('TripItStrategy').addBatch({
         assert.equal(profile.username, 'jaredhanson');
         assert.equal(profile.displayName, 'Jared Hanson');
         assert.equal(profile.emails.length, 2);
-        assert.equal(profile.emails[0], 'jaredhanson@example.com');
-        assert.equal(profile.emails[1], 'jaredhanson@example.net');
+        assert.deepEqual(profile.emails[0], { value: 'jaredhanson@example.com' });
+        assert.deepEqual(profile.emails[1], { value: 'jaredhanson@example.net' });
       },
       'should set raw property' : function(err, profile) {
         assert.isString(profile._raw);

--- a/test/strategy-test.js
+++ b/test/strategy-test.js
@@ -5,7 +5,7 @@ var TripItStrategy = require('passport-tripit/strategy');
 
 
 vows.describe('TripItStrategy').addBatch({
-  
+
   'strategy': {
     topic: function() {
       return new TripItStrategy({
@@ -14,12 +14,12 @@ vows.describe('TripItStrategy').addBatch({
       },
       function() {});
     },
-    
+
     'should be named tripit': function (strategy) {
       assert.equal(strategy.name, 'tripit');
     },
   },
-  
+
   'strategy when loading user profile': {
     topic: function() {
       var strategy = new TripItStrategy({
@@ -27,7 +27,7 @@ vows.describe('TripItStrategy').addBatch({
         consumerSecret: 'secret'
       },
       function() {});
-      
+
       // mock
       strategy._oauth.get = function(url, token, tokenSecret, callback) {
         var body = '{ \
@@ -63,25 +63,25 @@ vows.describe('TripItStrategy').addBatch({
                 "ical_url": "webcal:\/\/www.tripit.com\/feed\/ical\/private\/XXXXXXXX-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\/tripit.ics" \
             } \
         }';
-        
+
         callback(null, body, undefined);
       }
-      
+
       return strategy;
     },
-    
+
     'when told to load user profile': {
       topic: function(strategy) {
         var self = this;
         function done(err, profile) {
           self.callback(err, profile);
         }
-        
+
         process.nextTick(function () {
           strategy.userProfile('token', 'token-secret', {}, done);
         });
       },
-      
+
       'should not error' : function(err, req) {
         assert.isNull(err);
       },
@@ -90,6 +90,9 @@ vows.describe('TripItStrategy').addBatch({
         assert.equal(profile.id, 'XXxxXxxXX-xXNx_XXNNNXx');
         assert.equal(profile.username, 'jaredhanson');
         assert.equal(profile.displayName, 'Jared Hanson');
+        assert.equal(profile.emails.length, 2);
+        assert.equal(profile.emails[0], 'jaredhanson@example.com');
+        assert.equal(profile.emails[1], 'jaredhanson@example.net');
       },
       'should set raw property' : function(err, profile) {
         assert.isString(profile._raw);
@@ -99,7 +102,7 @@ vows.describe('TripItStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy when loading user profile and encountering an error': {
     topic: function() {
       var strategy = new TripItStrategy({
@@ -107,27 +110,27 @@ vows.describe('TripItStrategy').addBatch({
         consumerSecret: 'secret'
       },
       function() {});
-      
+
       // mock
       strategy._oauth.get = function(url, token, tokenSecret, callback) {
         callback(new Error('something went wrong'));
       }
-      
+
       return strategy;
     },
-    
+
     'when told to load user profile': {
       topic: function(strategy) {
         var self = this;
         function done(err, profile) {
           self.callback(err, profile);
         }
-        
+
         process.nextTick(function () {
           strategy.userProfile('token', 'token-secret', {}, done);
         });
       },
-      
+
       'should error' : function(err, req) {
         assert.isNotNull(err);
       },


### PR DESCRIPTION
emails associated with Tripit account can be extracted from:

Profile.ProfileEmailAddress.ProfileEmailAddress.addres

ProfileEmailAddress is an array of objects, but only if there is more
than one e-mail defined (clearly whatever generates JSON at TripIt does
not care about the schema)

see: https://api.tripit.com/xsd/tripit-api-obj-v1.xsd
